### PR TITLE
correct the file path in the sonarqube report.

### DIFF
--- a/TrxToSonar/Converter.cs
+++ b/TrxToSonar/Converter.cs
@@ -24,7 +24,7 @@ namespace TrxToSonar
             return _sonarParser.Save(sonarDocument, outputFilename);
         }
 
-        public SonarDocument Parse(string solutionDirectory, bool useAbsolutePath)
+        public SonarDocument Parse(string solutionDirectory, bool useAbsolutePath, bool usePDBFile)
         {
             if (string.IsNullOrEmpty(solutionDirectory) || !Directory.Exists(solutionDirectory))
             {
@@ -38,7 +38,7 @@ namespace TrxToSonar
             {
                 _logger.LogInformation($"Parsing: {trxFile}");
                 TrxDocument trxDocument = _trxParser.Deserialize(trxFile);
-                SonarDocument sonarDocument = Convert(trxDocument, solutionDirectory, useAbsolutePath);
+                SonarDocument sonarDocument = Convert(trxDocument, solutionDirectory, useAbsolutePath, usePDBFile);
 
                 if (sonarDocument != null)
                 {
@@ -69,7 +69,7 @@ namespace TrxToSonar
             return result;
         }
 
-        private SonarDocument Convert(TrxDocument trxDocument, string solutionDirectory, bool useAbsolutePath)
+        private SonarDocument Convert(TrxDocument trxDocument, string solutionDirectory, bool useAbsolutePath, bool usePDBFile)
         {
             var sonarDocument = new SonarDocument();
 
@@ -77,7 +77,7 @@ namespace TrxToSonar
             {
                 UnitTest unitTest = trxResult.GetUnitTest(trxDocument);
 
-                string testFile = unitTest.GetTestFile(solutionDirectory, useAbsolutePath);
+                string testFile = unitTest.GetTestFile(solutionDirectory, useAbsolutePath, usePDBFile);
 
                 File file = sonarDocument.GetFile(testFile);
 

--- a/TrxToSonar/IConverter.cs
+++ b/TrxToSonar/IConverter.cs
@@ -4,7 +4,7 @@ namespace TrxToSonar
 {
     public interface IConverter
     {
-        SonarDocument Parse(string solutionDirectory, bool useAbsolutePath);
+        SonarDocument Parse(string solutionDirectory, bool useAbsolutePath, bool usePDBFile);
 
         bool Save(SonarDocument sonarDocument, string outputFilename);
     }

--- a/TrxToSonar/Program.cs
+++ b/TrxToSonar/Program.cs
@@ -26,6 +26,7 @@ namespace TrxToSonar
                 app.Option("-d", "Solution Directory to parse.", CommandOptionType.SingleValue);
             CommandOption outputOption = app.Option("-o", "Output filename.", CommandOptionType.SingleValue);
             CommandOption absolutePathOption = app.Option("-a|--absolute", "Use Absolute Path", CommandOptionType.NoValue);
+            CommandOption usePDBFileOption = app.Option("-p|--pdb", "Use pdb file", CommandOptionType.NoValue);
 
             app.OnExecute(
                 () =>
@@ -33,7 +34,7 @@ namespace TrxToSonar
                     if (solutionDirectoryOption.HasValue() && outputOption.HasValue())
                     {
                         var converter = serviceProvider.GetService<IConverter>();
-                        SonarDocument sonarDocument = converter.Parse(solutionDirectoryOption.Value(), absolutePathOption.HasValue());
+                        SonarDocument sonarDocument = converter.Parse(solutionDirectoryOption.Value(), absolutePathOption.HasValue(), usePDBFileOption.HasValue());
                         converter.Save(sonarDocument, outputOption.Value());
                     }
                     else


### PR DESCRIPTION
Fix the file path in case the namespace path is not corresponding the file path. Use the pdb (In case is generated) determine the real file path.